### PR TITLE
feat: Add seeder user data file

### DIFF
--- a/seeders/20200727142100-user-data.js
+++ b/seeders/20200727142100-user-data.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const bcrypt = require('bcryptjs')
+const faker = require('faker')
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    /*
+      Add altering commands here.
+      Return a promise to correctly handle asynchronicity.
+
+      Example:
+      return queryInterface.bulkInsert('People', [{
+        name: 'John Doe',
+        isBetaMember: false
+      }], {});
+    */
+
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+        // 5 個一般使用者
+        queryInterface.bulkInsert('Users',
+          Array.from({ length: 5 }).map((d, i) =>
+            ({
+              name: `User${i + 1}`,
+              account: `test${i + 1}`,
+              email: `test${i + 1}@example.com`,
+              password: bcrypt.hashSync('12345678', bcrypt.genSaltSync(10), null),
+              tweetCount: 10,
+              role: 0,
+              createdAt: new Date(),
+              updatedAt: new Date()
+            })
+          ), { transaction: t }),
+
+        // 每個使用者有 10 篇 post
+        queryInterface.bulkInsert('Tweets',
+          Array.from({ length: 50 }).map((d, i) =>
+            ({
+              UserId: Math.ceil((i + 1) / 10) + 1, // root is id 1, so start from 2
+              description: faker.lorem.text().substring(0, 140), // 140 字以內
+              createdAt: new Date(),
+              updatedAt: new Date()
+            })
+          ), { transaction: t }),
+
+        // 每篇 post 有隨機 3 個留言者，每個人有 1 則留言
+        queryInterface.bulkInsert('Replies',
+          Array.from({ length: 30 }).map((d, i) =>
+            ({
+              UserId: Math.floor(Math.random() * 5) + 1,
+              TweetId: Math.ceil((i + 1) / 3),
+              comment: faker.lorem.text().substring(0, 140),
+              createdAt: new Date(),
+              updatedAt: new Date()
+            })
+          ), { transaction: t })
+      ]);
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    /*
+      Add reverting commands here.
+      Return a promise to correctly handle asynchronicity.
+
+      Example:
+      return queryInterface.bulkDelete('People', null, {});
+    */
+
+    // 要用 TRUNCATE，id 才會歸零
+    return Promise.all([
+      queryInterface.bulkDelete('Users', null, { truncate: true }),
+      queryInterface.bulkDelete('Tweets', null, { truncate: true }),
+      queryInterface.bulkDelete('Replies', null, { truncate: true })
+    ])
+  }
+};


### PR DESCRIPTION
建立一般使用者的種子資料：

5 個一般使用者
每個使用者有 10 篇 post
每篇 post 有隨機 3 個留言者，每個人有 1 則留言

p.s.
新增指令：npx sequelize db:seed:all
清除指令：npx sequelize db:seed:undo:all