### PR TITLE
fixed: destroy() cause wrong SQL

### DIFF
--- a/controllers/followshipController.js
+++ b/controllers/followshipController.js
@@ -68,10 +68,8 @@ const followshipController = {
           if (!results[1]) return res.json({ status: 'error', message: '沒有此追蹤資料，故無法刪除' })
 
           const followingUser = results[0]
-          const followship = results[1]
 
-          // 刪除追蹤關係
-          return followship.destroy()
+          return Followship.destroy({ where: { followerId, followingId } })
             .then(followship => {
               // 更新 follower user 資料: 追蹤別人數量、following user 資料: 被別人追蹤數量
               return User.findByPk(followerId)
@@ -81,6 +79,7 @@ const followshipController = {
                   return res.json({ status: 'success', message: '成功刪除一組追蹤關係' })
                 })
             })
+
         })
     } catch (err) {
       console.warn(err)


### PR DESCRIPTION
(wrong: DELETE FROM `Followships` WHERE `followerId` = x LIMIT 1)

之前的追蹤異常問題，還有現在的 Like 異常問題，似乎都出在 destroy() 產生的 SQL 不完全

刪除追蹤 destroy 產生的 SQL：
DELETE FROM `Followships` WHERE `followerId` = x LIMIT 1

刪除按讚 destroy 產生的 SQL：
DELETE FROM `Likes` WHERE `UserId` = 4 AND `ReplyId` IS NULL LIMIT 1

我先把刪除的 destroy 改掉了，產生的 SQL 就正常：DELETE FROM `Followships` WHERE `followerId` = 2 AND `followingId` = 4

你看一下，如果 ok 的話，也可以如法炮製到 Like 上面